### PR TITLE
Checks if enriched occupations and locations are in ad headline and a…

### DIFF
--- a/tests/integration_tests/test_enrich_platsannons.py
+++ b/tests/integration_tests/test_enrich_platsannons.py
@@ -36,6 +36,7 @@ def test_get_and_enrich_ad_details():
     occupations = enriched_ad['keywords']['enriched']['occupation']
 
     assert 'mattläggare' in occupations
+    assert 'golvläggare' in occupations
 
     assert 'luleå' in geos
 


### PR DESCRIPTION
…dds them even though the prediction value is below threshold. Take 2.
Had to put structured values back in input to the enrich-API, otherwise we will miss synonym searches for some values, like 'Skåne' for 'Skåne län'.