### PR TITLE
Feature/nar 399 occupations locations in removed ads

### DIFF
--- a/importers/platsannons/converter.py
+++ b/importers/platsannons/converter.py
@@ -31,6 +31,9 @@ def _isodate(bad_date):
 def convert_ad(message):
     annons = dict()
     start_time = int(time.time() * 1000)
+    if 'removed_ad_filter' in message:
+        annons['removed_ad_filter'] = message.get('removed_ad_filter')
+
     annons['id'] = message.get('annonsId')
     annons['external_id'] = message.get('externtAnnonsId')
     annons['headline'] = message.get('annonsrubrik')

--- a/importers/platsannons/loader.py
+++ b/importers/platsannons/loader.py
@@ -49,59 +49,35 @@ def bulk_fetch_ad_details(ad_batch):
 def load_ad_details(ad_meta):
     fail_count = 0
     fail_max = settings.LA_ANNONS_MAX_TRY
+    # TODO Refactor remove ad part to function
     ad_id = ad_meta['annonsId']
     if ad_meta.get('avpublicerad', False):
         log.info(f"Ad is avpublicerad, preparing to remove it: {ad_id}")
         removed_date = ad_meta.get('avpubliceringsdatum') or \
                        time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ad_meta.get('uppdateradTid') / 1000))
 
-        #LOCATION_LIST = ['region', 'city', 'country', 'municipality']
-        occupation = None
-        occupation_field = None
-        occupation_group = None
-        workplace_address = None
+        occupation_concept_id = None
+        occupation_group_concept_id = None
+        occupation_field_concept_id = None
+        municipality_concept_id = None
+        region_concept_id = None
+        country_concept_id = None
         ad_from_elastic = elastic.get_ad_by_id(ad_id)
         if ad_from_elastic is not None:
             occupation = ad_from_elastic.get('occupation')
+            if occupation is not None:
+                occupation_concept_id = occupation.get('concept_id')
             occupation_field = ad_from_elastic.get('occupation_field')
+            if occupation_field is not None:
+                occupation_field_concept_id = occupation_field.get('concept_id')
             occupation_group = ad_from_elastic.get('occupation_group')
+            if occupation_group is not None:
+                occupation_group_concept_id = occupation_group.get('concept_id')
             workplace_address = ad_from_elastic.get('workplace_address')
-
-        # ad_from_elastic = {
-        #     "occupation": {
-        #         "concept_id": "rM7G_ge7_XhP",
-        #         "label": "Barnskötare",
-        #         "legacy_ams_taxonomy_id": "5716"
-        #     },
-        #     "occupation_group": {
-        #         "concept_id": "Hi9c_iTe_gHH",
-        #         "label": "Barnskötare",
-        #         "legacy_ams_taxonomy_id": "5311"
-        #     },
-        #     "occupation_field": {
-        #         "concept_id": "GazW_2TU_kJw",
-        #         "label": "Socialt arbete",
-        #         "legacy_ams_taxonomy_id": "16"
-        #     },
-        #     "workplace_address" : {
-        #         "municipality_code" : "1280",
-        #         "municipality_concept_id" : "oYPt_yRA_Smm",
-        #         "municipality" : "Malmö",
-        #         "region_code" : "12",
-        #         "region_concept_id" : "CaRE_1nn_cSU",
-        #         "region" : "Skåne län",
-        #         "country_code" : "199",
-        #         "country_concept_id" : "i46j_HmG_v64",
-        #         "country" : "Sverige",
-        #         "street_address" : '',
-        #         "postcode" : '',
-        #         "city" : '',
-        #         "coordinates" : [
-        #             13.003822,
-        #             55.60498
-        #         ]
-        #     }
-        # }
+            if workplace_address is not None:
+                municipality_concept_id = workplace_address.get('municipality_concept_id')
+                region_concept_id = workplace_address.get('region_concept_id')
+                country_concept_id = workplace_address.get('country_concept_id')
 
         return {'annonsId': ad_id,
                 'id': ad_id,
@@ -113,10 +89,12 @@ def load_ad_details(ad_meta):
                 'updatedAt': ad_meta.get('uppdateradTid'),
                 'timestamp': ad_meta.get('uppdateradTid'),
                 'removed_ad_filter': {
-                'occupation': occupation,
-                'occupation_field': occupation_field,
-                'occupations_group': occupation_group,
-                'workplace_address': workplace_address}
+                'occupation_concept_id': occupation_concept_id,
+                'occupation_field_concept_id': occupation_field_concept_id,
+                'occupation_group_concept_id': occupation_group_concept_id,
+                'municipality_concept_id': municipality_concept_id,
+                'region_concept_id': region_concept_id,
+                'country_concept_id': country_concept_id }
                 }
 
     detail_url_la = settings.LA_DETAILS_URL + str(ad_id)

--- a/importers/platsannons/loader.py
+++ b/importers/platsannons/loader.py
@@ -46,56 +46,61 @@ def bulk_fetch_ad_details(ad_batch):
 
     return result_output
 
-def load_ad_details(ad_meta):
-    fail_count = 0
-    fail_max = settings.LA_ANNONS_MAX_TRY
-    # TODO Refactor remove ad part to function
-    ad_id = ad_meta['annonsId']
-    if ad_meta.get('avpublicerad', False):
-        log.info(f"Ad is avpublicerad, preparing to remove it: {ad_id}")
-        removed_date = ad_meta.get('avpubliceringsdatum') or \
-                       time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ad_meta.get('uppdateradTid') / 1000))
+def load_ad_to_remove(unpublished_ad_meta):
+    # Populate an unpublished ad with details
+    ad_id = unpublished_ad_meta['annonsId']
+    log.info(f"Ad is avpublicerad, preparing to remove it: {ad_id}")
+    removed_date = unpublished_ad_meta.get('avpubliceringsdatum') or \
+                   time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(unpublished_ad_meta.get('uppdateradTid') / 1000))
+    occupation_concept_id = None
+    occupation_group_concept_id = None
+    occupation_field_concept_id = None
+    municipality_concept_id = None
+    region_concept_id = None
+    country_concept_id = None
+    # Fetch filtering details for unpublished ad from Elastic Search...
+    ad_from_elastic = elastic.get_ad_by_id(ad_id)
+    if ad_from_elastic is not None:
+        occupation = ad_from_elastic.get('occupation')
+        if occupation is not None:
+            occupation_concept_id = occupation.get('concept_id')
+        occupation_field = ad_from_elastic.get('occupation_field')
+        if occupation_field is not None:
+            occupation_field_concept_id = occupation_field.get('concept_id')
+        occupation_group = ad_from_elastic.get('occupation_group')
+        if occupation_group is not None:
+            occupation_group_concept_id = occupation_group.get('concept_id')
+        workplace_address = ad_from_elastic.get('workplace_address')
+        if workplace_address is not None:
+            municipality_concept_id = workplace_address.get('municipality_concept_id')
+            region_concept_id = workplace_address.get('region_concept_id')
+            country_concept_id = workplace_address.get('country_concept_id')
 
-        occupation_concept_id = None
-        occupation_group_concept_id = None
-        occupation_field_concept_id = None
-        municipality_concept_id = None
-        region_concept_id = None
-        country_concept_id = None
-        ad_from_elastic = elastic.get_ad_by_id(ad_id)
-        if ad_from_elastic is not None:
-            occupation = ad_from_elastic.get('occupation')
-            if occupation is not None:
-                occupation_concept_id = occupation.get('concept_id')
-            occupation_field = ad_from_elastic.get('occupation_field')
-            if occupation_field is not None:
-                occupation_field_concept_id = occupation_field.get('concept_id')
-            occupation_group = ad_from_elastic.get('occupation_group')
-            if occupation_group is not None:
-                occupation_group_concept_id = occupation_group.get('concept_id')
-            workplace_address = ad_from_elastic.get('workplace_address')
-            if workplace_address is not None:
-                municipality_concept_id = workplace_address.get('municipality_concept_id')
-                region_concept_id = workplace_address.get('region_concept_id')
-                country_concept_id = workplace_address.get('country_concept_id')
-
-        return {'annonsId': ad_id,
-                'id': ad_id,
-                'removed': True,
-                'avpublicerad': True,
-                'avpubliceringsdatum': removed_date,
-                'removed_date': removed_date,
-                'uppdateradTid': ad_meta.get('uppdateradTid'),
-                'updatedAt': ad_meta.get('uppdateradTid'),
-                'timestamp': ad_meta.get('uppdateradTid'),
-                'removed_ad_filter': {
+    return {'annonsId': ad_id,
+            'id': ad_id,
+            'removed': True,
+            'avpublicerad': True,
+            'avpubliceringsdatum': removed_date,
+            'removed_date': removed_date,
+            'uppdateradTid': unpublished_ad_meta.get('uppdateradTid'),
+            'updatedAt': unpublished_ad_meta.get('uppdateradTid'),
+            'timestamp': unpublished_ad_meta.get('uppdateradTid'),
+            'removed_ad_filter': {
                 'occupation_concept_id': occupation_concept_id,
                 'occupation_field_concept_id': occupation_field_concept_id,
                 'occupation_group_concept_id': occupation_group_concept_id,
                 'municipality_concept_id': municipality_concept_id,
                 'region_concept_id': region_concept_id,
                 'country_concept_id': country_concept_id }
-                }
+            }
+
+def load_ad_details(ad_meta):
+    fail_count = 0
+    fail_max = settings.LA_ANNONS_MAX_TRY
+    ad_id = ad_meta['annonsId']
+    # If ad is unpublished; handle it as removed...
+    if ad_meta.get('avpublicerad', False):
+        return load_ad_to_remove(ad_meta)
 
     detail_url_la = settings.LA_DETAILS_URL + str(ad_id)
     while True:

--- a/importers/repository/elastic.py
+++ b/importers/repository/elastic.py
@@ -29,23 +29,27 @@ def _bulk_generator(documents, indexname, idkey, deleted_index):
 
         if document.get('removed', False):
             if deleted_index:
-                if 'removed_ad_filter' in document:
-                    removed_ad_filter = document.get('removed_ad_filter')
-                    occupation = removed_ad_filter.get('occupation', None)
-                    occupation_group = removed_ad_filter.get('occupation_group', None)
-                    occupation_field = removed_ad_filter.get('occupation_field', None)
-                    workplace_address = removed_ad_filter.get('workplace_address', None)
+
                 tombstone = {
                     'id': doc_id,
                     'removed': True,
                     'removed_date': document.get('removed_date'),
                     'timestamp': document.get('timestamp'),
-                    'publication_date': None,
                     'last_publication_date': None,
-                    'occupation': occupation,
-                    'occupation_group': occupation_group,
-                    'occupation_field': occupation_field,
-                    'workplace_address': workplace_address
+                    'occupation': {
+                        'concept_id': document.get('removed_ad_filter', {}).get('occupation_concept_id')
+                    } ,
+                    'occupation_group': {
+                        'concept_id': document.get('removed_ad_filter', {}).get('occupation_group_concept_id')
+                    },
+                    'occupation_field': {
+                        'concept_id': document.get('removed_ad_filter', {}).get('occupation_field_concept_id')
+                    },
+                    'workplace_address': {
+                        'municipality_concept_id': document.get('removed_ad_filter', {}).get('municipality_concept_id'),
+                        'region_concept_id': document.get('removed_ad_filter', {}).get('region_concept_id'),
+                        'country_concept_id': document.get('removed_ad_filter', {}).get('country_concept_id')
+                    }
                 }
                 yield {
                     '_index': indexname,

--- a/importers/repository/elastic.py
+++ b/importers/repository/elastic.py
@@ -36,6 +36,10 @@ def _bulk_generator(documents, indexname, idkey, deleted_index):
                     'timestamp': document.get('timestamp'),
                     'publication_date': None,
                     'last_publication_date': None,
+                    'occupation': document.get('occupation'),
+                    'occupation_group': document.get('occupation_group'),
+                    'occupation_field': document.get('occupation_field'),
+                    'workplace_address': document.get('workplace_address')
                 }
                 yield {
                     '_index': indexname,

--- a/tests/integration_tests/test_enrich_platsannons.py
+++ b/tests/integration_tests/test_enrich_platsannons.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pytest
-from importers.platsannons.loader import load_details_from_la
+from importers.platsannons.loader import load_ad_details
 from importers.platsannons import converter, enricher_mt_rest_multiple as enricher
 
 
@@ -14,7 +14,7 @@ def test_get_and_enrich_ad_details():
     annons_id = 23888740
     ad_meta = {'annonsId': annons_id, 'avpublicerad': False, 'uppdateradTid': 1582272745821}
 
-    ad_detail = load_details_from_la(ad_meta=ad_meta)
+    ad_detail = load_ad_details(ad_meta=ad_meta)
     ad_details = {}
     ad_details[annons_id] = ad_detail
     converted_ads = [converter.convert_ad(ad) for ad in ad_details.values()]


### PR DESCRIPTION
Contains code for adding occupations and locations concept_id:s to unpublished ads that are being moved to removed-index in Elastic Search.